### PR TITLE
Env example details and documentation fix of /answer

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,5 @@
+root = true
+
+[*]
+indent_style = space
+indent_size = 2

--- a/README.md
+++ b/README.md
@@ -51,13 +51,13 @@ nexmo link:app [LVN] [app-id]
 Update the app to set the webhook urls to be your server instead of the example.com placeholders used at creation.
 
 ```sh
-nexmo app:update ['app-id'] demo-app [your url]/call [your url]/event
+nexmo app:update ['app-id'] demo-app [your url]/answer [your url]/event
 ```
 
 We recommend using [ngrok](https://ngrok.com/) to tunnel through to your locally running application. In which case the command above is likely to be something similar to:
 
 ```sh
-nexmo app:update ['app-id'] demo-app https://___.ngrok.io/call https://___.ngrok.io/event
+nexmo app:update ['app-id'] demo-app https://___.ngrok.io/answer https://___.ngrok.io/event
 ```
 
 Where `___` should be replaced with the `ngrok.io` subdomain you are assigned.

--- a/example.env
+++ b/example.env
@@ -1,4 +1,4 @@
-# The URL of your server
+# The URL to your server (localhost won't work)
 BASE_URL=https://12345abc.ngrok.io/
 
 # Your Nexmo account information viewable at https://dashboard.nexmo.com/settings

--- a/example.env
+++ b/example.env
@@ -1,14 +1,24 @@
-BASE_URL=...
+# The URL of your server
+BASE_URL=https://12345abc.ngrok.io/
 
-NEXMO_API_KEY=...
-NEXMO_API_SECRET=...
+# Your Nexmo account information viewable at https://dashboard.nexmo.com/settings
+NEXMO_API_KEY=12345678
+NEXMO_API_SECRET=1234a1234567a1a1
 
-APP_UUID=...
+# This app's ID and key
+# View your IDs by running `nexmo apps:list`
+# You specified the key when you created the app using `nexmo app:create demo-app --keyfile key.txt`
+APP_UUID=12345678-1234-1234-1234-123456789012
 KEY_FILE=key.txt
 
-INBOUND_NUMBER=...
-INBOUND_NUMBER_COUNTRY_CODE=...
-PROXY_TO_NUMBER=...
+# Phone number information
+# Inbound number is the LVN used for this app (See all your numbers at https://dashboard.nexmo.com/your-numbers )
+# Link the number to this app using `nexmo link:app [LVN] [app-id]`
+# Proxy number is the one to receive the call
+INBOUND_NUMBER=1234567890
+INBOUND_NUMBER_COUNTRY_CODE=US
+PROXY_TO_NUMBER=9876543210
 
-PUBNUB_PUB_KEY=pub-c-...
-PUBSUB_SUB_KEY=sub-c-...
+# Pubnub information
+PUBNUB_PUB_KEY=pub-c-12345678-1234-1234-1234-123456789012
+PUBSUB_SUB_KEY=sub-c-12345678-1234-1234-1234-123456789012

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "nexmo-node-call-tracking",
   "version": "0.1.0",
-  "description": "An Call Tracking example using the Nexmo Voice API written in Node.",
+  "description": "A Call Tracking example using the Nexmo Voice API written in Node.",
   "repository": {
     "type": "git",
     "url": "git@github.com:nexmo-community/nexmo-node-call-tracking.git"

--- a/views/index.ejs
+++ b/views/index.ejs
@@ -11,26 +11,26 @@
     <script>
     function sub() {
 
-        pubnub = PUBNUB({
-            subscribe_key : '<%= pubNubSubKey %>'
-        })
- 
-        console.log("Subscribing..");
-        pubnub.subscribe({                                     
-            channel : "call",
-            message : function (message, envelope, channelOrGroup, time, channel) {
-                console.log(
-                    "Message Received:" +  time + "\n" +                    
-                    JSON.stringify(message) + "\n"
-                )
-            },
-            connect : console.log('Connected')
-        })
+      pubnub = PUBNUB({
+        subscribe_key : '<%= pubNubSubKey %>'
+      })
+
+      console.log("Subscribing..");
+      pubnub.subscribe({                                     
+        channel : "call",
+        message : function (message, envelope, channelOrGroup, time, channel) {
+          console.log(
+            "Message Received:" +  time + "\n" +                    
+            JSON.stringify(message) + "\n"
+          )
+        },
+        connect : console.log('Connected')
+      })
     };
     
     $( document ).ready(function() {
-        console.log( "Ready!" );
-        sub();
+      console.log( "Ready!" );
+      sub();
     });
     </script>
 	</head>


### PR DESCRIPTION
- Added details describing how to obtain the .env values
- Changed /call to /answer in readme documentation
- Added editorconfig and indentation fixes
